### PR TITLE
Replace LaundryButton with RegenerateOutfitButton

### DIFF
--- a/src/components/regenerate-outfit-button.tsx
+++ b/src/components/regenerate-outfit-button.tsx
@@ -1,0 +1,25 @@
+import { useOutfit } from "../hooks/outfit.ts";
+import { RiAiGenerate } from "react-icons/ri";
+
+export default function RegenerateOutfitButton() {
+  const { generateOutfit, canGenerateOutfit } = useOutfit();
+
+  function onRegenerate(): void {
+    generateOutfit();
+  }
+
+  return (
+    <button
+      onClick={() => onRegenerate()}
+      aria-label="Regenerate the outfit"
+      title="Regenerate the outfit"
+      className={`fixed bottom-12 right-5 z-50 rounded-full shadow-lg transition-colors border btn-accent border-gray-200 disabled:cursor-not-allowed  disabled:border-gray-300`}
+      style={{ width: 56, height: 56 }}
+      disabled={!canGenerateOutfit()}
+    >
+      <div className="flex items-center justify-center text-3xl">
+        <RiAiGenerate />
+      </div>
+    </button>
+  );
+}

--- a/src/hooks/outfit.ts
+++ b/src/hooks/outfit.ts
@@ -141,11 +141,19 @@ export const useOutfit = () => {
 
   const clearOutfit = (): void => emitChange(null);
 
+  const canGenerateOutfit = (): boolean => {
+    const cleanItems = items.filter((i) => i.isClean);
+    const availableTops = cleanItems.filter((i) => i.category === "top");
+    const availableBottoms = cleanItems.filter((i) => i.category === "bottom");
+
+    return availableTops.length > 0 && availableBottoms.length > 0;
+  };
+
   function emitChange(newOutfit: Outfit | null): void {
     listeners.forEach((listener) => listener(newOutfit));
     localStorage.setItem(OUTFIT_LOCAL_STORAGE_KEY, JSON.stringify(newOutfit));
     state = newOutfit;
   }
 
-  return { outfit, generateOutfit, clearOutfit };
+  return { outfit, generateOutfit, clearOutfit, canGenerateOutfit };
 };

--- a/src/pages/suggest-page.tsx
+++ b/src/pages/suggest-page.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 import NavigationBar from "../components/navigation-bar.tsx";
-import LaundryButton from "../components/laundry-button.tsx";
 import type { Outfit } from "../models/outfit.ts";
 import { useOutfit } from "../hooks/outfit.ts";
 import { useCloset } from "../hooks/closet.ts";
 import { useImage } from "../hooks/image.ts";
+import RegenerateOutfitButton from "../components/regenerate-outfit-button.tsx";
 
 interface TouchDragState {
   key: keyof Outfit | null;
@@ -19,8 +19,7 @@ interface TouchDragState {
 const EmptyMessageTemplate = () => (
   <div className="relative mx-auto w-full max-w-md h-64 md:h-80 flex items-center justify-center">
     <div className="suggest-card rounded-4xl p-4 text-muted text-center">
-      No outfit right now — maybe it's laundry time? Tap{" "}
-      <span className="font-medium">Laundry</span>.
+      No outfit right now — maybe it's laundry time?
     </div>
   </div>
 );
@@ -270,7 +269,7 @@ export const SuggestPage = (): React.JSX.Element => {
       </div>
 
       <NavigationBar activePage="suggest" />
-      <LaundryButton />
+      <RegenerateOutfitButton />
     </>
   );
 };


### PR DESCRIPTION
```markdown
### What does this PR do?

This pull request replaces the `LaundryButton` with a new `RegenerateOutfitButton` component in `suggest-page.tsx`. It introduces logic to handle button states utilizing the `canGenerateOutfit` mechanism through `useOutfit`. The new button includes a disabled state and dynamic styling. Additionally, outdated copy in `EmptyMessageTemplate` was cleaned up.

### Checklist

- [ ] Code has been tested locally by the developer.
- [ ] Documentation has been updated (if applicable).
- [ ] Changes follow coding standards and guidelines.

```