### PR TITLE
Refactor `useOutfit` and replace LaundryButton with RegenerateOutfitButton

### DIFF
--- a/src/components/regenerate-outfit-button.tsx
+++ b/src/components/regenerate-outfit-button.tsx
@@ -1,0 +1,25 @@
+import { useOutfit } from "../hooks/outfit.ts";
+import { RiAiGenerate } from "react-icons/ri";
+
+export default function RegenerateOutfitButton() {
+  const { generateOutfit, canGenerateOutfit } = useOutfit();
+
+  function onRegenerate(): void {
+    generateOutfit();
+  }
+
+  return (
+    <button
+      onClick={() => onRegenerate()}
+      aria-label="Regenerate the outfit"
+      title="Regenerate the outfit"
+      className={`fixed bottom-12 right-5 z-50 rounded-full shadow-lg transition-colors border btn-accent border-gray-200 disabled:cursor-not-allowed  disabled:border-gray-300`}
+      style={{ width: 56, height: 56 }}
+      disabled={!canGenerateOutfit()}
+    >
+      <div className="flex items-center justify-center text-3xl">
+        <RiAiGenerate />
+      </div>
+    </button>
+  );
+}

--- a/src/hooks/outfit.ts
+++ b/src/hooks/outfit.ts
@@ -141,11 +141,19 @@ export const useOutfit = () => {
 
   const clearOutfit = (): void => emitChange(null);
 
+  const canGenerateOutfit = (): boolean => {
+    const cleanItems = items.filter((i) => i.isClean);
+    const availableTops = cleanItems.filter((i) => i.category === "top");
+    const availableBottoms = cleanItems.filter((i) => i.category === "bottom");
+
+    return availableTops.length > 0 && availableBottoms.length > 0;
+  };
+
   function emitChange(newOutfit: Outfit | null): void {
     listeners.forEach((listener) => listener(newOutfit));
     localStorage.setItem(OUTFIT_LOCAL_STORAGE_KEY, JSON.stringify(newOutfit));
     state = newOutfit;
   }
 
-  return { outfit, generateOutfit, clearOutfit };
+  return { outfit, generateOutfit, clearOutfit, canGenerateOutfit };
 };

--- a/src/hooks/outfit.ts
+++ b/src/hooks/outfit.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import type { Outfit } from "../models/outfit.ts";
 import { useCloset } from "./closet.ts";
-import type { ClothingItem } from "../models/clothing-item.ts";
 import type { Color } from "../models/color.ts";
 import { differenceCiede2000 } from "culori";
 
@@ -28,30 +27,13 @@ const scoreColors = ({ a, b }: { a: Color; b: Color }): number | null => {
   // Convert distance to score (0-1, where 1 is closest). Delta E of 100 is quite different, 0 is identical
   return 1 - Math.min(distance / 100, 1);
 };
-const findBestMatch = ({
-  candidates,
-  anchor,
-}: {
-  candidates: ClothingItem[];
-  anchor: ClothingItem;
-}): ClothingItem => {
-  let bestItem: Partial<ClothingItem> = {};
-  let bestScore = -1;
 
-  for (const candidate of candidates) {
-    const score = scoreColors({
-      a: anchor.color,
-      b: candidate.color,
-    });
-
-    if (score && score > bestScore) {
-      bestScore = score;
-      bestItem = candidate;
-    }
+const isSameOutfit = (a: Outfit | null, b: Outfit | null): boolean => {
+  if (!a || !b) {
+    return false;
   }
 
-  // bestItem is now fully defined so we can cast it safely
-  return bestItem as ClothingItem;
+  return a.top.id === b.top.id && a.bottom.id === b.bottom.id;
 };
 
 const initialize = () => {
@@ -99,40 +81,29 @@ export const useOutfit = () => {
       return null;
     }
 
-    const maxAttempts = cleanItems.length;
-    let bestOutfit = {} as Outfit;
+    // Prefer the best-scoring outfit among all valid combinations,
+    // but never return the exact same (top+bottom) as the current one.
+    let bestOutfit: Outfit | null = null;
     let highestScore = -1;
 
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const item = cleanItems[Math.floor(Math.random() * cleanItems.length)];
-      const currentOutfit: Partial<Outfit> = {
-        top: item.category === "top" ? item : undefined,
-        bottom: item.category === "bottom" ? item : undefined,
-      };
+    for (const top of availableTops) {
+      for (const bottom of availableBottoms) {
+        const candidate: Outfit = { top, bottom };
+        if (isSameOutfit(candidate, outfit)) {
+          continue;
+        }
 
-      if (!currentOutfit.bottom) {
-        currentOutfit.bottom = findBestMatch({
-          candidates: availableBottoms,
-          anchor: currentOutfit.top!,
-        });
+        const score = scoreColors({ a: top.color, b: bottom.color });
+        if (score && score > highestScore) {
+          highestScore = score;
+          bestOutfit = candidate;
+        }
       }
+    }
 
-      if (!currentOutfit.top) {
-        currentOutfit.top = findBestMatch({
-          candidates: availableTops,
-          anchor: currentOutfit.bottom!,
-        });
-      }
-
-      const score = scoreColors({
-        a: currentOutfit.top.color,
-        b: currentOutfit.bottom.color,
-      });
-
-      if (score && score > highestScore) {
-        highestScore = score;
-        bestOutfit = currentOutfit as Outfit; // Outfit is now fully defined so we can cast it safely
-      }
+    // If there is no alternative outfit, don't change the current one.
+    if (!bestOutfit) {
+      return null;
     }
 
     emitChange(bestOutfit);
@@ -146,7 +117,21 @@ export const useOutfit = () => {
     const availableTops = cleanItems.filter((i) => i.category === "top");
     const availableBottoms = cleanItems.filter((i) => i.category === "bottom");
 
-    return availableTops.length > 0 && availableBottoms.length > 0;
+    if (availableTops.length === 0 || availableBottoms.length === 0) {
+      return false;
+    }
+    if (!outfit) {
+      // If there is no current outfit yet, regenerating/generating is possible.
+      return true;
+    }
+
+    // Only if there is another available outfit.
+    return availableTops.some((topItem) =>
+      availableBottoms.some(
+        (bottomItem) =>
+          topItem.id !== outfit.top.id || bottomItem.id !== outfit.bottom.id,
+      ),
+    );
   };
 
   function emitChange(newOutfit: Outfit | null): void {

--- a/src/pages/suggest-page.tsx
+++ b/src/pages/suggest-page.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 import NavigationBar from "../components/navigation-bar.tsx";
-import LaundryButton from "../components/laundry-button.tsx";
 import type { Outfit } from "../models/outfit.ts";
 import { useOutfit } from "../hooks/outfit.ts";
 import { useCloset } from "../hooks/closet.ts";
 import { useImage } from "../hooks/image.ts";
+import RegenerateOutfitButton from "../components/regenerate-outfit-button.tsx";
 
 interface TouchDragState {
   key: keyof Outfit | null;
@@ -19,8 +19,7 @@ interface TouchDragState {
 const EmptyMessageTemplate = () => (
   <div className="relative mx-auto w-full max-w-md h-64 md:h-80 flex items-center justify-center">
     <div className="suggest-card rounded-4xl p-4 text-muted text-center">
-      No outfit right now — maybe it's laundry time? Tap{" "}
-      <span className="font-medium">Laundry</span>.
+      No outfit right now — maybe it's laundry time?
     </div>
   </div>
 );
@@ -270,7 +269,7 @@ export const SuggestPage = (): React.JSX.Element => {
       </div>
 
       <NavigationBar activePage="suggest" />
-      <LaundryButton />
+      <RegenerateOutfitButton />
     </>
   );
 };


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- Refactored `useOutfit` hook to simplify outfit generation logic:
  - Replaced `findBestMatch` with a direct scoring mechanism for all combinations.
  - Added `isSameOutfit` function to prevent duplicate outfits.
  - Improved `canGenerateOutfit` function to consider the current outfit state.
  - Removed unused imports and legacy logic from the module.

- Replaced the `LaundryButton` component with a new `RegenerateOutfitButton`:
  - Updated `suggest-page.tsx` with the new button.
  - Added logic from `canGenerateOutfit` to handle button state.
  - Created a styled and dynamic `RegenerateOutfitButton` with disabled state support.
  - Cleaned outdated copy within the `EmptyMessageTemplate`.

### Checklist

- [ ] Tested on multiple devices and scenarios.
- [ ] Documentation updated where necessary.
- [ ] Code adheres to style guidelines.