### PR TITLE
Add upload limit validation and UI adjustments in ClosetPage

### DIFF
--- a/src/hooks/closet.ts
+++ b/src/hooks/closet.ts
@@ -5,6 +5,7 @@ import {
 } from "../models/clothing-item";
 
 const ITEMS_LOCAL_STORAGE_KEY = "closet";
+const ITEMS_UPLOAD_LIMIT = 10;
 
 // Private singleton state reused through the app
 let state: ClothingItem[] = [];
@@ -77,6 +78,9 @@ export function useCloset() {
   const areAllItemsClean = (): boolean => {
     return state.every((i) => i.isClean);
   };
+  const isUploadLimitReached = (): boolean => {
+    return state.length >= ITEMS_UPLOAD_LIMIT;
+  };
 
   function emitChange(newItems: ClothingItem[]): void {
     listeners.forEach((listener) => listener(newItems));
@@ -92,5 +96,6 @@ export function useCloset() {
     markWorn,
     isItemClean,
     areAllItemsClean,
+    isUploadLimitReached,
   };
 }

--- a/src/modals/upload-clothing-item-modal.tsx
+++ b/src/modals/upload-clothing-item-modal.tsx
@@ -5,6 +5,7 @@ import {
   type CreateClothingItem,
 } from "../models/clothing-item.ts";
 import type { Color } from "../models/color.ts";
+import { useCloset } from "../hooks/closet.ts";
 
 const MAX_IMAGE_SIZE = 256;
 const COMPRESSION_QUALITY = 0.5;
@@ -108,6 +109,7 @@ export default function UploadClothingItemModal({
   onClose,
   onSave,
 }: ModalData) {
+  const { isUploadLimitReached } = useCloset();
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [name, setName] = useState("");
@@ -140,6 +142,14 @@ export default function UploadClothingItemModal({
     try {
       setIsSaving(true);
       setError(null);
+
+      if (isUploadLimitReached()) {
+        setError(
+          "You've hit our current MVP limit of 10 items. We're working on expanding this soon!",
+        );
+        setIsSaving(false);
+        return;
+      }
 
       if (!file) {
         setError("Please choose an image.");

--- a/src/pages/closet-page.tsx
+++ b/src/pages/closet-page.tsx
@@ -100,16 +100,23 @@ const ItemCard = ({ item }: { item: ClothingItem }): React.JSX.Element => {
 };
 const AddItemButton = ({
   onClick,
+  disabled,
 }: {
   onClick: () => void;
+  disabled: boolean;
 }): React.JSX.Element => {
   return (
     <div className="flex justify-center">
       <button
         onClick={onClick}
+        disabled={disabled}
         aria-label="Add a new item to your closet"
-        title="Add a new item to your closet"
-        className={`fixed bottom-12 right-5 z-50 shadow-lg primary-button transition-all`}
+        title={
+          disabled
+            ? "The limit of uploaded items has been reached"
+            : "Add a new item to your closet"
+        }
+        className={`fixed bottom-12 right-5 z-50 shadow-lg primary-button transition-all ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
         style={{ width: 56, height: 56 }}
       >
         <div className="flex items-center justify-center text-3xl">
@@ -145,7 +152,7 @@ const LaundryButton = (): React.JSX.Element => {
 };
 
 export const ClosetPage = (): React.JSX.Element => {
-  const { items, addClothingItem } = useCloset();
+  const { items, addClothingItem, isUploadLimitReached } = useCloset();
   const { saveImage } = useImage();
   const [selectedCategory, setSelectedCategory] =
     useState<ClothingItemCategory | null>(null);
@@ -191,7 +198,10 @@ export const ClosetPage = (): React.JSX.Element => {
       </div>
 
       <NavigationBar activePage="closet" />
-      <AddItemButton onClick={() => setShowUploadModal(true)} />
+      <AddItemButton
+        onClick={() => setShowUploadModal(true)}
+        disabled={isUploadLimitReached()}
+      />
 
       {showUploadModal && (
         <UploadClothingItemModal


### PR DESCRIPTION
### What was done

- Added upload limit validation to `upload-clothing-item-modal`.
- Updated `useCloset` hook to include `isUploadLimitReached` logic.
- Disabled `AddItemButton` on the ClosetPage when the upload limit is reached.
- Improved error handling and button accessibility for better user experience.

### Checklist

- [ ] Tests added or updated as necessary
- [ ] Documentation updated, if required
- [ ] Code reviewed for best practices and adherence to standards