### PR TITLE
Add Docker Compose setup for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+dist-ssr
+.git
+*.env
+.idea
+.vscode
+.DS_Store
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine
+
+# Install Doppler CLI
+RUN wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.key' -O /etc/apk/keys/cli@doppler-8004D9FF50437357.rsa.pub && \
+    echo 'https://packages.doppler.com/public/cli/alpine/any-version/main' >> /etc/apk/repositories && \
+    apk add --no-cache doppler
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+
+ENTRYPOINT []
+CMD ["doppler", "run", "--", "npx", "vite", "--host=0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  app:
+    build: .
+    ports:
+      - "5173:5173"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - DOPPLER_TOKEN


### PR DESCRIPTION
## Summary
- Added a `Dockerfile` based on `node:22-alpine` with Doppler CLI installed via `apk`
- Added a `docker-compose.yml` with bind mount for hot reload and Doppler token injection via `.env`
- Added a `.dockerignore` to exclude `node_modules`, `dist`, `.git`, etc.

## Details
This setup allows running the Vite dev server in a Docker container with secrets managed by Doppler. No manual token passing is needed — just create a `.env` file with `DOPPLER_TOKEN` and run `docker compose up`.

## Test plan
- [x] Create a `.env` file with `DOPPLER_TOKEN=<your-token>`
- [x] Run `docker compose up --build`
- [x] Verify the app loads at `http://localhost:5173`
- [x] Verify hot reload works by modifying a `.tsx` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)