### PR TITLE
Move laundry basket to closet page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run lint     # ESLint
 - [x] Outfit drag-and-drop — drag the whole outfit to the basket instead of individual items
 - [x] Strikethrough dirty items — replace clean/dirty badges with a visual strikethrough on items in the laundry, also on the favourites page
 - [x] Replace drag-and-drop on today page — replace with a simpler interaction (e.g. a confirm button) to improve discoverability
-- [ ] Move basket to closet page — the laundry basket fits better on the closet page; rethink the today page layout so it doesn't feel empty without it
+- [x] Move basket to closet page — the laundry basket fits better on the closet page; rethink the today page layout so it doesn't feel empty without it
 - [ ] More categories — shoes, accessories, jackets/coats
 - [ ] Improved onboarding — guided tour for new users
 - [ ] Horizontal scroll views — closet page with one row per category (tops, bottoms) scrolling horizontally; favourites page with a single horizontal row of outfits

--- a/src/pages/closet-page.tsx
+++ b/src/pages/closet-page.tsx
@@ -171,6 +171,7 @@ export const ClosetPage = (): React.JSX.Element => {
     [selectedCategory, items],
   );
 
+
   async function addItem(item: CreateClothingItem): Promise<void> {
     const newItem = await addClothingItem(item);
 
@@ -183,58 +184,71 @@ export const ClosetPage = (): React.JSX.Element => {
   }
 
   return (
-    <>
-      <div className="mx-auto max-w-4xl p-4 pb-2">
+    <div className="flex flex-col h-screen overflow-hidden">
+      <div className="mx-auto max-w-4xl p-4 pb-2 w-full shrink-0">
         <h2 className="page-title">Your closet</h2>
       </div>
 
-      <FilterBar
-        selectedCategory={selectedCategory}
-        onCategorySelected={setSelectedCategory}
-      />
+      <div className="shrink-0">
+        <FilterBar
+          selectedCategory={selectedCategory}
+          onCategorySelected={setSelectedCategory}
+        />
+      </div>
 
-      <div className="w-full mx-auto max-w-4xl p-4 pb-64">
+      <div className="shrink-0 w-full mx-auto max-w-4xl px-4 pt-4">
         <LaundryButton />
+      </div>
 
-        <div className="rounded-2xl">
-          {filteredItems.length > 0 ? (
-            <div className="grid gap-2 grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-              {filteredItems.map((item) => (
-                <ItemCard key={item.id} item={item} />
-              ))}
-            </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center py-12 text-center">
-              <p className="text-gray-500 text-lg">
-                No items found in this category.
-              </p>
-              <p className="text-gray-400 text-sm">
-                Try selecting a different filter or add a new item!
-              </p>
-            </div>
-          )}
+      <div
+        className="flex-1 min-h-0 overflow-y-auto"
+        style={{
+          maskImage: "linear-gradient(to bottom, transparent, black 1.5rem, black calc(100% - 3rem), transparent)",
+          WebkitMaskImage: "linear-gradient(to bottom, transparent, black 1.5rem, black calc(100% - 3rem), transparent)",
+        }}
+      >
+        <div className="w-full mx-auto max-w-4xl px-4 pb-8">
+          <div className="rounded-2xl">
+            {filteredItems.length > 0 ? (
+              <div className="grid gap-2 grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+                {filteredItems.map((item) => (
+                  <ItemCard key={item.id} item={item} />
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <p className="text-gray-500 text-lg">
+                  No items found in this category.
+                </p>
+                <p className="text-gray-400 text-sm">
+                  Try selecting a different filter or add a new item!
+                </p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
+      {/* Spacer for basket overflow */}
+      <div className="shrink-0 h-8" />
+
       {/* Basket */}
       <div
-        className="fixed bottom-16 left-1/2 -translate-x-1/2 p-2 w-64 md:w-80 h-44 md:h-56 flex items-center justify-center pointer-events-none"
+        className="shrink-0 mx-auto w-64 md:w-80 h-44 md:h-56 mb-16 flex items-center justify-center pointer-events-none"
         aria-label="Wear basket"
       >
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div
-            style={{
-              width: "100%",
-              aspectRatio: "1/2",
-              backgroundImage: "url(/assets/basket-grid.png)",
-              backgroundRepeat: "no-repeat",
-              backgroundSize: "200% 100%",
-              backgroundPosition: areAllItemsClean() ? "0 0" : "94% 0",
-              imageRendering: "auto",
-            }}
-            aria-label={areAllItemsClean() ? "Empty basket" : "Full basket"}
-          />
-        </div>
+        <div
+          style={{
+            width: "100%",
+            aspectRatio: "1/2",
+            backgroundImage: "url(/assets/basket-grid.png)",
+            backgroundRepeat: "no-repeat",
+            backgroundSize: "200% 100%",
+            backgroundPosition: areAllItemsClean() ? "0 0" : "94% 0",
+            imageRendering: "auto",
+          }}
+          aria-label={areAllItemsClean() ? "Empty basket" : "Full basket"}
+        />
       </div>
 
       <NavigationBar activePage="closet" />
@@ -249,6 +263,6 @@ export const ClosetPage = (): React.JSX.Element => {
           onSave={addItem}
         />
       )}
-    </>
+    </div>
   );
 };

--- a/src/pages/closet-page.tsx
+++ b/src/pages/closet-page.tsx
@@ -157,7 +157,7 @@ const LaundryButton = (): React.JSX.Element => {
 };
 
 export const ClosetPage = (): React.JSX.Element => {
-  const { items, addClothingItem, isUploadLimitReached } = useCloset();
+  const { items, addClothingItem, isUploadLimitReached, areAllItemsClean } = useCloset();
   const { saveImage } = useImage();
   const [selectedCategory, setSelectedCategory] =
     useState<ClothingItemCategory | null>(null);
@@ -193,7 +193,7 @@ export const ClosetPage = (): React.JSX.Element => {
         onCategorySelected={setSelectedCategory}
       />
 
-      <div className="w-full mx-auto max-w-4xl p-4 pb-24">
+      <div className="w-full mx-auto max-w-4xl p-4 pb-64">
         <LaundryButton />
 
         <div className="rounded-2xl">
@@ -213,6 +213,27 @@ export const ClosetPage = (): React.JSX.Element => {
               </p>
             </div>
           )}
+        </div>
+      </div>
+
+      {/* Basket */}
+      <div
+        className="fixed bottom-16 left-1/2 -translate-x-1/2 p-2 w-64 md:w-80 h-44 md:h-56 flex items-center justify-center pointer-events-none"
+        aria-label="Wear basket"
+      >
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div
+            style={{
+              width: "100%",
+              aspectRatio: "1/2",
+              backgroundImage: "url(/assets/basket-grid.png)",
+              backgroundRepeat: "no-repeat",
+              backgroundSize: "200% 100%",
+              backgroundPosition: areAllItemsClean() ? "0 0" : "94% 0",
+              imageRendering: "auto",
+            }}
+            aria-label={areAllItemsClean() ? "Empty basket" : "Full basket"}
+          />
         </div>
       </div>
 

--- a/src/pages/today-page.tsx
+++ b/src/pages/today-page.tsx
@@ -6,7 +6,8 @@ import { useCloset } from "../hooks/closet.ts";
 import { useImage } from "../hooks/image.ts";
 import { useOutfitHistory } from "../hooks/outfit-history.ts";
 import { useFavouriteOutfits } from "../hooks/favourite-outfits.ts";
-import { FaCheck, FaHeart, FaRegHeart, FaSyncAlt } from "react-icons/fa";
+import { FaCheck, FaHeart, FaRegHeart, FaSyncAlt, FaTshirt } from "react-icons/fa";
+import { useNavigate } from "react-router";
 import "../pages/today-page.css";
 
 const FavouriteButton = () => {
@@ -41,14 +42,25 @@ const FavouriteButton = () => {
   );
 };
 
-const EmptyMessageTemplate = () => (
-  <div className="relative mx-auto w-full max-w-md h-64 md:h-80 flex items-center justify-center">
-    <div className="flex flex-col items-center justify-center py-12 text-center">
-      <p className="text-gray-500 text-lg">No outfit right now.</p>
-      <p className="text-gray-400 text-sm">Maybe it's laundry time?</p>
+const EmptyMessageTemplate = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="relative mx-auto w-full max-w-md flex items-center justify-center">
+      <div className="flex flex-col items-center justify-center py-12 text-center gap-4">
+        <FaTshirt className="text-8xl text-gray-400" />
+        <p className="text-gray-500 text-lg">No outfit right now.</p>
+        <p className="text-gray-400 text-sm">All your clothes are in the basket — time to do laundry!</p>
+        <button
+          onClick={() => navigate("/closet")}
+          className="primary-button px-6 py-3 text-base font-semibold mt-2"
+        >
+          Go to closet
+        </button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 const RegenerateOutfitFab = () => {
   const { generateOutfit, canGenerateOutfit } = useOutfit();
 
@@ -112,8 +124,8 @@ const OutfitTemplate = (): React.JSX.Element => {
             }
 
             return (
-              <div className="relative mx-auto w-full max-w-sm">
-                <div className="card flex flex-col items-center gap-4 p-5 relative">
+              <div className="relative mx-auto w-full max-w-md">
+                <div className="card flex flex-col items-center gap-6 relative" style={{ padding: "1.5rem" }}>
                   <FavouriteButton />
                   {/* Top item */}
                   {outfit.top && isItemClean(outfit.top.id) && (
@@ -121,7 +133,7 @@ const OutfitTemplate = (): React.JSX.Element => {
                       <img
                         src={getImage(outfit.top.id)}
                         alt={outfit.top.name}
-                        className="w-36 h-36 object-contain rounded-xl"
+                        className="w-44 h-44 object-contain rounded-xl"
                         loading="lazy"
                       />
                       <div className="mt-2 text-sm text-black font-semibold whitespace-nowrap text-ellipsis w-full overflow-hidden text-center">
@@ -138,7 +150,7 @@ const OutfitTemplate = (): React.JSX.Element => {
                       <img
                         src={getImage(outfit.bottom.id)}
                         alt={outfit.bottom.name}
-                        className="w-36 h-36 object-contain rounded-xl"
+                        className="w-44 h-44 object-contain rounded-xl"
                         loading="lazy"
                       />
                       <div className="mt-2 text-sm text-black font-semibold whitespace-nowrap text-ellipsis w-full overflow-hidden text-center">
@@ -169,18 +181,18 @@ const OutfitTemplate = (): React.JSX.Element => {
 
 export const TodayPage = (): React.JSX.Element => {
   return (
-    <>
+    <div className="flex flex-col flex-1 min-h-screen">
       {/* Header */}
-      <div className="mx-auto max-w-4xl p-4 pb-2">
+      <div className="absolute top-0 left-0 right-0 mx-auto max-w-4xl p-4 pb-2">
         <h2 className="page-title">Today's outfit</h2>
       </div>
 
-      <div className="w-full mx-auto max-w-4xl p-4 pb-24">
+      <div className="w-full mx-auto max-w-4xl px-4 flex-1 flex items-center justify-center mb-16">
         <OutfitTemplate />
       </div>
 
       <NavigationBar activePage="today" />
       <RegenerateOutfitFab />
-    </>
+    </div>
   );
 };

--- a/src/pages/today-page.tsx
+++ b/src/pages/today-page.tsx
@@ -73,7 +73,7 @@ const RegenerateOutfitFab = () => {
 };
 const OutfitTemplate = (): React.JSX.Element => {
   const { getImage } = useImage();
-  const { isItemClean, areAllItemsClean, markWorn } = useCloset();
+  const { isItemClean, markWorn } = useCloset();
   const { outfit, clearOutfit, generateOutfit } = useOutfit();
   const { recordOutfit } = useOutfitHistory();
   const [isMarking, setIsMarking] = useState(false);
@@ -163,27 +163,7 @@ const OutfitTemplate = (): React.JSX.Element => {
         <EmptyMessageTemplate />
       )}
 
-      {/* Basket */}
-      <div
-        className="fixed bottom-16 left-1/2 -translate-x-1/2 p-2 w-64 md:w-80 h-44 md:h-56 flex items-center justify-center pointer-events-none"
-        aria-label="Wear basket"
-      >
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div
-            style={{
-              width: "100%",
-              aspectRatio: "1/2",
-              backgroundImage: "url(/assets/basket-grid.png)",
-              backgroundRepeat: "no-repeat",
-              backgroundSize: "200% 100%",
-              backgroundPosition: areAllItemsClean() ? "0 0" : "94% 0",
-              imageRendering: "auto",
-            }}
-            aria-label={areAllItemsClean() ? "Empty basket" : "Full basket"}
-          />
-        </div>
-      </div>
-    </div>
+</div>
   );
 };
 


### PR DESCRIPTION
## Summary
- Moved the laundry basket visual from the today page to the closet page, where it fits more naturally alongside dirty/clean item management
- Improved today page layout: outfit card is now vertically centered with larger images
- Added a richer empty state on the today page with an icon and a "Go to closet" button when no outfit is available

## Test plan
- [x] Verify the basket appears on the closet page and reflects dirty/clean state correctly
- [x] Verify the basket no longer appears on the today page
- [x] Verify the today page outfit card is vertically centered
- [x] Verify the empty state displays the icon, message, and "Go to closet" button
- [x] Verify the "Go to closet" button navigates correctly
- [x] Verify closet page items don't overlap with the basket

🤖 Generated with [Claude Code](https://claude.com/claude-code)